### PR TITLE
Refresh Azure identity token every 5 minutes

### DIFF
--- a/Armadillo.Client/wwwroot/index.html
+++ b/Armadillo.Client/wwwroot/index.html
@@ -11,6 +11,11 @@
 </head>
 <body>
 <app>Loading...</app>
+    
+<script>
+    setInterval(() => fetch('/.auth/refresh'), 60000 * 5 ) 
+</script>
+    
 <script src="_framework/blazor.webassembly.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This refresh prevents the dashboard from logging off the logged in user